### PR TITLE
chore: add rebeccapurple to list of named html colors

### DIFF
--- a/colorzero/tables.py
+++ b/colorzero/tables.py
@@ -432,6 +432,7 @@ NAMED_COLORS = {
     'plum':                  '#dda0dd',
     'powderblue':            '#b0e0e6',
     'purple':                '#800080',
+    'rebeccapurple':         '#663399',
     'red':                   '#ff0000',
     'rosybrown':             '#bc8f8f',
     'royalblue':             '#4169e1',


### PR DESCRIPTION
Thanks for maintaining a great library!

This small PR adds the named HTML color 'rebeccapurple`, which was added in [CSS Color Module Level 4](https://drafts.csswg.org/css-color-4/#valdef-color-rebeccapurple)

Let me know if I can be of any further help :)